### PR TITLE
enabled VPN mode for policy based VPN GW

### DIFF
--- a/modules/vpn-gateway/README.md
+++ b/modules/vpn-gateway/README.md
@@ -53,7 +53,7 @@ module "vpn_gateway" {
 | tags | List of tags to attach  | list(string) | n/a | no |
 | vpn\_gateway | Existing VPN Gatewayp's ID to which connections are to be attached | string | n/a | no |
 | connections | VPN Gateway connections | list | n/a | no |
-| mode | VPN mode | string | n/a | no |
+| mode | VPN mode, required for policy based VPN | string | n/a | no |
 
 ## Outputs
 

--- a/modules/vpn-gateway/README.md
+++ b/modules/vpn-gateway/README.md
@@ -34,6 +34,7 @@ module "vpn_gateway" {
   resource_group_id  = data.ibm_resource_group.resource_group.id
   subnet             = var.subnet
   tags               = var.tags
+  mode               = var.mode
   vpn_gateway        = var.vpn_gateway
   connections        = var.connections
 }
@@ -52,6 +53,7 @@ module "vpn_gateway" {
 | tags | List of tags to attach  | list(string) | n/a | no |
 | vpn\_gateway | Existing VPN Gatewayp's ID to which connections are to be attached | string | n/a | no |
 | connections | VPN Gateway connections | list | n/a | no |
+| mode | VPN mode | string | n/a | no |
 
 ## Outputs
 

--- a/modules/vpn-gateway/main.tf
+++ b/modules/vpn-gateway/main.tf
@@ -8,6 +8,7 @@ resource "ibm_is_vpn_gateway" "vpngw" {
   name           = var.name
   resource_group = var.resource_group_id
   subnet         = (var.subnet != null ? var.subnet : null)
+  mode           = (var.mode != null ? var.mode : null)
   tags           = (var.tags != null ? var.tags : [])
 }
 

--- a/modules/vpn-gateway/variables.tf
+++ b/modules/vpn-gateway/variables.tf
@@ -43,6 +43,11 @@ variable "vpn_gateway" {
   default     = null
 }
 
+variable "mode"  {
+  description = "VPN Mode, route or policy"
+  type        = string
+  default     = null
+}
 
 variable "connections" {
   description = "List of connections for the VPN Gateway"


### PR DESCRIPTION
### Description

By default, VPN gateway is provisioned with route mode, if we use this module, there is no way to provision policy based VPN gateway. 
This PR, exposes the VPN mode. 

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [* ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ *] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
