### PR TITLE
fix:classic_access_deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_address_prefixes"></a> [address\_prefixes](#input\_address\_prefixes) | List of Prefixes for the vpc | <pre>list(object({<br/>    name     = string<br/>    location = string<br/>    ip_range = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_auto_assign_address_prefix"></a> [auto\_assign\_address\_prefix](#input\_auto\_assign\_address\_prefix) | Set to true to create a default address prefix automatically for each zone in the VPC. | `bool` | `true` | no |
-| <a name="input_classic_access"></a> [classic\_access](#input\_classic\_access) | Classic Access to the VPC | `bool` | `false` | no |
 | <a name="input_clean_default_sg_acl"></a> [clean\_default\_sg\_acl](#input\_clean\_default\_sg\_acl) | Remove all rules from the default VPC security group and VPC ACL (less permissive) | `bool` | `false` | no |
 | <a name="input_create_gateway"></a> [create\_gateway](#input\_create\_gateway) | True to create new Gateway | `bool` | `false` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | True to create new VPC. False if VPC is already existing and subnets or address prefixies are to be added | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,6 @@ module "vpc" {
   create_vpc                  = var.create_vpc
   vpc_name                    = var.vpc_name
   resource_group_id           = var.resource_group_id
-  classic_access              = var.classic_access
   default_address_prefix      = var.auto_assign_address_prefix ? "auto" : "manual"
   default_network_acl_name    = var.default_network_acl_name
   default_security_group_name = var.default_security_group_name

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -14,7 +14,6 @@ module "vpc" {
   create_vpc                  = var.create_vpc
   vpc_name                    = var.vpc_name
   resource_group_id           = data.ibm_resource_group.resource_group.id
-  classic_access              = var.classic_access
   default_address_prefix      = var.default_address_prefix
   default_network_acl_name    = var.default_network_acl_name
   default_security_group_name = var.default_security_group_name
@@ -59,7 +58,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_address_prefixes"></a> [address\_prefixes](#input\_address\_prefixes) | List of Prefixes for the vpc | <pre>list(object({<br/>    name     = string<br/>    location = string<br/>    ip_range = string<br/>  }))</pre> | `[]` | no |
-| <a name="input_classic_access"></a> [classic\_access](#input\_classic\_access) | Classic Access to the VPC | `bool` | `false` | no |
 | <a name="input_clean_default_sg_acl"></a> [clean\_default\_sg\_acl](#input\_clean\_default\_sg\_acl) | Remove all rules from the default VPC security group and VPC ACL (less permissive) | `bool` | `false` | no |
 | <a name="input_create_gateway"></a> [create\_gateway](#input\_create\_gateway) | True to create new Gateway | `bool` | `false` | no |
 | <a name="input_create_vpc"></a> [create\_vpc](#input\_create\_vpc) | True to create new VPC. False if VPC is already existing and subnets or address prefixies are to be added | `bool` | `true` | no |

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -12,7 +12,6 @@ resource "ibm_is_vpc" "vpc" {
   count                       = var.create_vpc ? 1 : 0
   name                        = var.vpc_name
   resource_group              = var.resource_group_id
-  classic_access              = var.classic_access
   address_prefix_management   = var.default_address_prefix
   default_network_acl_name    = var.default_network_acl_name
   default_security_group_name = var.default_security_group_name

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -25,11 +25,6 @@ variable "resource_group_id" {
   default     = null
 }
 
-variable "classic_access" {
-  description = "Classic Access to the VPC"
-  type        = bool
-  default     = false
-}
 
 variable "default_address_prefix" {
   description = "Default address prefix creation method"

--- a/variables.tf
+++ b/variables.tf
@@ -20,12 +20,6 @@ variable "resource_group_id" {
   default     = null
 }
 
-variable "classic_access" {
-  description = "Classic Access to the VPC"
-  type        = bool
-  default     = false
-}
-
 variable "auto_assign_address_prefix" {
   description = "Set to true to create a default address prefix automatically for each zone in the VPC."
   type        = bool


### PR DESCRIPTION
### Description

This PR is to  fix the issue of classic access variable deprecated.Removed the variable classic access from vpc module and root module.
[git issue:11521](https://github.ibm.com/GoldenEye/issues/issues/11521)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fixed the issue of "classic access argument deprecated".

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
